### PR TITLE
INFRASYS-5410 Use salt instead of redis.keys lookup, fixed tests related...

### DIFF
--- a/salinity/salinity_front/models.py
+++ b/salinity/salinity_front/models.py
@@ -5,6 +5,7 @@ This is the models module. This is where I will put all the relevant classes.
 import redis
 import jsonpickle
 from time import time
+import salt.wheel
 
 class CheckRedis(object):
     """
@@ -20,7 +21,7 @@ class CheckRedis(object):
         """
         Check for failed highstates
         """
-        server_list = self.get_server_list("*" + role + "*" + env)
+        server_list = self.get_server_list(role,env)
         try:
             for server in (server for server in server_list if server):
                 if self.check_failed_highstate(server, self.find_last_highstate(server)):
@@ -29,15 +30,15 @@ class CheckRedis(object):
                 return "GREEN"
         except TypeError:
             return "None"
-    def get_server_list(self, glob):
+    def get_server_list(self, role, env):
         """
         Using the server glob, find a matching list of servers in
         redis returns so that they can be checked individually.
         """
-        server_list = []
-        for result in self.con.keys(glob + "*:state.highstate"):
-            server_list.append(result.split(":")[0])
-        return server_list
+        opts = salt.config.master_config('/etc/salt/master')
+        saltWheel = salt.wheel.Wheel(opts)
+        serverList = saltWheel.call_func('key.list', **{ 'match' : 'accepted' })['minions']
+        return [server for server in serverList if role in server and env in server]
     def find_last_highstate(self, server):
         """
         Check the server:state.highstate list entry for
@@ -67,8 +68,11 @@ class CheckRedis(object):
     def write_context(self, context):
         self.con.set("saved_context_dict", context)
         self.con.set("saved_context_timestamp", time()) 
-    def update_redis_context(self, envs, roles):
-        timestamp = float(self.con.get("saved_context_timestamp"))
+    def update_redis_context(self, envs, roles, timestamp=0.0):
+        try:
+            timestamp = float(self.con.get("saved_context_timestamp"))
+        except:
+            pass
         now = time()
         if abs(timestamp - now) > 300:
             context_dict = {}

--- a/salinity/salinity_front/tests.py
+++ b/salinity/salinity_front/tests.py
@@ -4,6 +4,7 @@ Test will go here, hopefully in the first iteration
 from django.test import TestCase
 from salinity_front.models import CheckRedis
 from mock import MagicMock
+import salt.wheel
 
 class CheckRedisTests(TestCase):
     """
@@ -16,17 +17,18 @@ class CheckRedisTests(TestCase):
         """
         Build the mock of checkredis, allows testing without real redis data
         """
-        self.checkredis.con.keys = MagicMock(name="method")
-        self.checkredis.con.keys.return_value = ['aw1-php70-qa', 'aw1-php80-qa']
         self.checkredis.con.lindex = MagicMock(name="method")
         self.checkredis.con.lindex.return_value = "01"
         self.checkredis.con.get = MagicMock(name="method")
-        self.checkredis.con.get.return_value = "This Highstate went well"
+        self.checkredis.con.get.return_value = "{\"jid\": \"01\", \"return\": {\"service_|-sshd_|-sshd_|-running\": {\"comment\": \"Service sshd is already enabled, and is in the desired state\", \"__run_num__\": 98, \"changes\": {}, \"name\": \"sshd\", \"result\": true}}}"
+        salt.wheel.Wheel.call_func = MagicMock(name="method")
+        salt.wheel.Wheel.call_func.return_value = {"minions": ['aw1-php70-qa', 'aw1-php80-qa']} 
+
     def test_get_server_list(self):
         """
         Find the list of servers (Mocked)
         """
-        self.assertEqual(sorted(self.checkredis.get_server_list("*php*qa")), sorted(['aw1-php70-qa', 'aw1-php80-qa']))
+        self.assertEqual(sorted(self.checkredis.get_server_list("php","qa")), sorted(['aw1-php70-qa', 'aw1-php80-qa']))
     def test_find_last_highstate(self):
         """
         Find the last highstate (Mocked)


### PR DESCRIPTION
... to changes.

```
mgorman@MGORMAN-MBPR:salinity (INFRASYS-5410)$ ./manage.py test -v 2 salinity_front
nosetests salinity_front --verbosity=2
Creating test database for alias 'default' (':memory:')...
Operations to perform:
  Apply all migrations: admin, contenttypes, auth, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying sessions.0001_initial... OK
Test the failed highstate (Mocked) ... ok
Test failed role, which walks through all the other items as well (Mocked results provided from all the above) ... ok
Find the last highstate (Mocked) ... ok
Find the list of servers (Mocked) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.455s

OK
Destroying test database for alias 'default' (':memory:')...
```
