### PR TITLE
(9.1.0) INFRASYS-5482 Add error handling and correc timing to stabilize salinity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+sudo: required
+before_install:
+  - sudo apt-get install -qq -y swig python-dev
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: pip install --quiet -r requirements.txt
+# # command to run tests, e.g. python setup.py test
+script: python salinity/manage.py test salinity_front

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/dandb/salinity.svg?branch=master)](https://travis-ci.org/dandb/salinity)
 __Description__
 ----------------
 This project is designed a django backed frontend which will parse redis information

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ mock==1.0.1
 nose==1.3.4
 pylint==1.4.0
 redis==2.10.3
+salt==0.17.1
 six==1.8.0
 wsgiref==0.1.2
 jsonpickle==0.9.2

--- a/salinity/salinity_front/tests.py
+++ b/salinity/salinity_front/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from salinity_front.models import CheckRedis
 from mock import MagicMock
 import salt.wheel
+import subprocess
 
 class CheckRedisTests(TestCase):
     """
@@ -23,6 +24,8 @@ class CheckRedisTests(TestCase):
         self.checkredis.con.get.return_value = "{\"jid\": \"01\", \"return\": {\"service_|-sshd_|-sshd_|-running\": {\"comment\": \"Service sshd is already enabled, and is in the desired state\", \"__run_num__\": 98, \"changes\": {}, \"name\": \"sshd\", \"result\": true}}}"
         salt.wheel.Wheel.call_func = MagicMock(name="method")
         salt.wheel.Wheel.call_func.return_value = {"minions": ['aw1-php70-qa', 'aw1-php80-qa']} 
+        subprocess.check_output = MagicMock(name="method")
+        subprocess.check_output.return_value = "{'aw1-php70-qa': ['10.26.40.112'], 'aw1-php80-qa': ['10.26.40.123'] }"
 
     def test_get_server_list(self):
         """


### PR DESCRIPTION
Fixes: 
Place the timestamp before starting instead of after finishing to prevent running multiple at once.
Increase time between checks to something slightly higher than actual time it takes to prevent a second thread from starting before the 1st is finished. 
Exception handle the highstate return for unexpected results that crashed the thread and prevented completion (one server had an authentication error stored as a list, was not iterable)
Exception handle salt query and set a default server to check incase of problems instead of crashing the thread and preventing completion.

Applied these changes to saltmaster for testing. Appears to be much more stable and working as expected. 
